### PR TITLE
Update test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -15,11 +15,11 @@ LDC_SAD_DIR=$(dirname $BASEDIR)/ldc_sad_hmm
 DIARTKDIR=$(dirname $BASEDIR)/ib_diarization_toolkit
 
 # First test ldc_sad_hmm
-cd $LDC_SAD_DIR
-$conda_dir/python perform_sad.py -L /vagrant /vagrant/test2.mp3 > /dev/null 2>&1 || exit 1
+#cd $LDC_SAD_DIR
+#$conda_dir/python perform_sad.py -L /vagrant /vagrant/test2.mp3 > /dev/null 2>&1 || exit 1
 # convert output to rttm, for diartk.
-grep ' speech' /vagrant/test2.lab | awk -v fname=$base '{print "SPEAKER" "\t" fname "\t" 1  "\t" $1  "\t" $2-$1 "\t" "<NA>" "\t" "<NA>"  "\t" $3  "\t"  "<NA>"}'   > /vagrant/test2.rttm
-echo "LDC_SAD passed the test..."
+#grep ' speech' /vagrant/test2.lab | awk -v fname=$base '{print "SPEAKER" "\t" fname "\t" 1  "\t" $1  "\t" $2-$1 "\t" "<NA>" "\t" "<NA>"  "\t" $3  "\t"  "<NA>"}'   > /vagrant/test2.rttm
+#echo "LDC_SAD passed the test..."
 
 # now test Noisemes
 cd $OPENSATDIR


### PR DESCRIPTION
Temporarily turn off the ldc_sad_hmm since we removed it per Neville Ryant's request.
Unfortunately this has to also be reflected in the Vagrantfile (don't install ldc_sad_hmm)
and also breaks the scoring scripts like evalSAD.sh
which try to run ldc_sad_hmm/score.py
